### PR TITLE
Add column resizing with persistence. Fix long paragraphs not wrapping. Add button to add column/row.

### DIFF
--- a/src/consts.ts
+++ b/src/consts.ts
@@ -8,5 +8,6 @@ export const EDITOR_TABLE_CONTAINER_CLASS = "obsidian-grid-tables-container";
 export const EDITOR_TABLE_ADD_COLUMN_BUTTON_CLASS = "obsidian-grid-tables-add-col-button";
 export const EDITOR_TABLE_ADD_ROW_BUTTON_CLASS = "obsidian-grid-tables-add-row-button";
 export const EDITOR_TABLE_BUTTON_CLASS = "obsidian-grid-tables-table-button";
+export const EDITOR_TABLE_RESIZE_HANDLE_CLASS = "obsidian-grid-tables-resize-handle";
 
 export const PLUS_SVG = `<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="svg-icon lucide-plus"><path d="M5 12h14"></path><path d="M12 5v14"></path></svg>`

--- a/src/consts.ts
+++ b/src/consts.ts
@@ -4,6 +4,7 @@ export const EDITOR_TABLE_ROW_CLASS = "obsidian-grid-tables-row";
 export const EDITOR_TABLE_CELL_CLASS = "obsidian-grid-tables-cell";
 
 export const EDITOR_TABLE_CONTAINER_CLASS = "obsidian-grid-tables-container";
+export const EDITOR_TABLE_SCROLL_CLASS = "obsidian-grid-tables-scroll";
 
 export const EDITOR_TABLE_ADD_COLUMN_BUTTON_CLASS = "obsidian-grid-tables-add-col-button";
 export const EDITOR_TABLE_ADD_ROW_BUTTON_CLASS = "obsidian-grid-tables-add-row-button";

--- a/styles.css
+++ b/styles.css
@@ -1,10 +1,5 @@
 /*
-
-This CSS file will be included with your plugin, and
-available in the app when your plugin is enabled.
-
-If your plugin does not need CSS, delete this file.
-
+This CSS file styles the grid-tables editor widget and its controls.
 */
 
 .obsidian-grid-tables-table-source {
@@ -14,6 +9,11 @@ If your plugin does not need CSS, delete this file.
 
 .obsidian-grid-tables-table {
     border-collapse: collapse;
+    /* Use fixed layout so column widths follow our explicit CSS widths rather than
+       being reflowed proportionally when the container size changes. */
+    table-layout: fixed;
+    /* Keep the table at its intrinsic width; let the container handle scrolling. */
+    width: max-content;
 }
 
 .obsidian-grid-tables-cell {
@@ -21,41 +21,90 @@ If your plugin does not need CSS, delete this file.
     border-collapse: collapse;
     padding: 0.5em;
     vertical-align: top;
+    position: relative;
 }
 
+.obsidian-grid-tables-resize-handle {
+    position: absolute;
+    top: 0;
+    right: -2px;
+    width: 4px;
+    height: 100%;
+    cursor: col-resize;
+    user-select: none;
+    z-index: 10;
+}
+
+.obsidian-grid-tables-resize-handle:hover {
+    background-color: var(--interactive-accent);
+    opacity: 0.4;
+}
+
+/* The container reserves a small gutter on the right and bottom for hot-zones */
 .obsidian-grid-tables-container {
+    /* Gutters are customizable via CSS vars to keep offsets in sync */
+    --gt-gutter-right: 19px;
+    --gt-gutter-bottom: 19px;
+
     display: flex;
     position: relative;
     width: fit-content;
+    padding-right: var(--gt-gutter-right);
+    padding-bottom: var(--gt-gutter-bottom);
+    /* Ensure children can render fully if they sit near the edge */
+    overflow: visible;
 }
 
+/* Generic hot-zone button styling */
 .obsidian-grid-tables-table-button {
-    border: 1px solid #333;
-    color: #333;
-    font-size: 1.5em;
+    border: 1px solid var(--background-modifier-border);
+    color: var(--text-muted);
+    background-color: var(--background-modifier-hover);
+    font-size: 1.1em;
     display: flex;
     justify-content: center;
     align-items: center;
     user-select: none;
     position: absolute;
+    z-index: 50;
+    cursor: pointer;
+    border-radius: 6px;
+    line-height: 1;
+    box-sizing: border-box; /* avoid clipping due to border */
+
+    /* Appear on hover only */
+    opacity: 0;
+    pointer-events: none;
+    transition: opacity 120ms ease;
+}
+
+/* Reveal on container hover */
+.obsidian-grid-tables-container:hover .obsidian-grid-tables-table-button {
+    opacity: 1;
+    pointer-events: auto;
 }
 
 .obsidian-grid-tables-table-button:hover {
-    border: 1px solid #666;
-    color: #666;
+    border-color: var(--interactive-accent);
+    color: var(--interactive-accent);
 }
 
+/* Right-side hot zone: narrow vertical bar inside the container gutter */
 .obsidian-grid-tables-table-button.obsidian-grid-tables-add-col-button {
-    border-left: 0;
     top: 0;
-    inset-inline-start: 100%;
-    border-inline-start: none;
-    height: 100%;
+    /* keep clear of the bottom gutter so it doesn't overlap the add-row button */
+    bottom: var(--gt-gutter-bottom);
+    /* keep the button fully inside the container to avoid CM clipping */
+    right: 2px;
+    width: 16px;            /* narrow vertical hot zone */
 }
 
+/* Bottom hot zone: short horizontal bar inside the container gutter */
 .obsidian-grid-tables-table-button.obsidian-grid-tables-add-row-button {
-    border-top: 0;
-    top: 100%;
-    width: 100%;
+    left: 0;
+    right: var(--gt-gutter-right); /* leave room for right gutter/hot-zone */
+    /* keep the button fully inside the container to avoid CM clipping */
+    bottom: 2px;
+    height: 16px;           /* smaller than empty-row height */
     flex-direction: row;
 }

--- a/styles.css
+++ b/styles.css
@@ -46,13 +46,26 @@ This CSS file styles the grid-tables editor widget and its controls.
     --gt-gutter-right: 19px;
     --gt-gutter-bottom: 19px;
 
-    display: flex;
+    display: inline-block; /* shrink to table width */
     position: relative;
-    width: fit-content;
+    width: max-content;     /* expand to fit table, but not full editor width */
+    max-width: none;
     padding-right: var(--gt-gutter-right);
     padding-bottom: var(--gt-gutter-bottom);
     /* Ensure children can render fully if they sit near the edge */
     overflow: visible;
+}
+
+/* Dedicated horizontal scroller so the table can overflow without scrolling the whole editor */
+.obsidian-grid-tables-scroll {
+    position: relative; /* establishes containing block for absolutely-positioned children if needed */
+    overflow-x: auto;
+    overflow-y: hidden;
+    width: 100%;
+    max-width: 100%;
+    -webkit-overflow-scrolling: touch;
+    overscroll-behavior-x: contain;
+    scrollbar-gutter: stable both-edges;
 }
 
 /* Generic hot-zone button styling */


### PR DESCRIPTION
## 1. Add column resizing. 

Introduce opinionated column resizing setting (default off) to store visual column widths as numeric hints alongside separator lines `+----SIZE+----SIZE+`. This allows column resizing and fixes bug, where it allowed only short sentences to be used (e.g. max column width would be of the length of the longest line - but this PR allows you to have any dimension you want).

You still can resize with the setting turned off, and it will keep syntax clean without adding size number in the headers, but then the minimum width of the column is limited by the longest line in the cell.


<img width="978" height="139" alt="image" src="https://github.com/user-attachments/assets/b2ebb306-fe28-4595-ac1f-c4294841ae43" />

![Obsidian_WTeFTLVwm5](https://github.com/user-attachments/assets/630f082b-7cea-483a-b3d4-db161450a6f5)

## 2. Add button to add column/row. Similar to defualt Obsidian tables, but with hand pointer! 

![Obsidian_DAefQ9NFJ0](https://github.com/user-attachments/assets/669513f5-8f11-414e-95f0-085bf69938f4)
![Obsidian_lJluW4qT10](https://github.com/user-attachments/assets/888a0477-31be-470f-8ab8-cfdc9fa4cfdf)



